### PR TITLE
Preliminary Python 3 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core libs
-requests==1.0.4
+requests==2.2.1
 
 # Testing/Dev
 nose==1.2.1

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     packages = find_packages(),
 
     install_requires = [
-        'requests==1.0.4',
+        'requests',
     ],
     package_data = {'assembla': []},
     entry_points = {},
@@ -56,5 +56,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
     ],
+    use_2to3 = True,
 )


### PR DESCRIPTION
This will run 2to3 on the codebase during install time to make it run
on Python 3.

It also drops the version pinning of the requests library so that the
latest version gets installed. It needs a significantly more recent
version of requests in order to work on Python 3.
